### PR TITLE
Fix package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafflebox-technologies-inc/rafflebox-logger-ui",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "main": "index.js",
   "typings": "index.d.ts",
   "repository": "https://github.com/rafflebox-technologies-inc/rafflebox-logger-ui.git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@rafflebox-technologies-inc/rafflebox-logger-ui",
   "version": "1.0.12",
   "main": "index.js",
-  "type": "module",
   "typings": "index.d.ts",
   "repository": "https://github.com/rafflebox-technologies-inc/rafflebox-logger-ui.git",
   "author": "Jamie Archibald <jamie.archibald@rafflebox.ca>",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "esnext",
+    "module": "commonjs",
     "moduleResolution": "Node",
     "lib": ["ESNext", "ESNext.AsyncIterable", "DOM"],
     "esModuleInterop": true,


### PR DESCRIPTION
For the nuxt SSR to support ES modules we would need to maintain a list of packages in the nuxt config, and potentially other projects that use this package.

Either way is fine but leaving it commonjs for now seems easier to me?