### PR TITLE
Allow tracing on logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafflebox-technologies-inc/rafflebox-logger-ui",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "main": "index.js",
   "typings": "index.d.ts",
   "repository": "https://github.com/rafflebox-technologies-inc/rafflebox-logger-ui.git",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -57,6 +57,10 @@ class Logger {
       console.log(message, data);
     }
   };
+
+  trace = (message: string, data: { [key: string]: any }, level?: Sentry.Severity) => {
+    Sentry.addBreadcrumb({ message, data, level });
+  };
 }
 
 const logger = new Logger();


### PR DESCRIPTION
Adds a trace functions that adds breadcrumbs on logs . 

The latest version for this package is 1.2.2 but it wasn't deployed using Github Actions that is why I am bumping the version up by 2.